### PR TITLE
feat: allow passing a lookup csv to populate or overwrite values

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,21 +11,23 @@ Extract NIMH Data Archive compatible metadata from Brain Imaging Data Structure 
 
 ## Usage
 
-    usage: bids2nda [-h] [-e EXPID_MAPPING] BIDS_DIRECTORY GUID_MAPPING OUTPUT_DIRECTORY
-
+    usage: bids2nda [-h] [-e EXPID_MAPPING] [--lookup_csv LOOKUP_CSV] [--lookup_fields LOOKUP_FIELDS [LOOKUP_FIELDS ...]] BIDS_DIRECTORY GUID_MAPPING OUTPUT_DIRECTORY
     BIDS to NDA converter.
 
     positional arguments:
-      BIDS_DIRECTORY    Location of the root of your BIDS compatible directory.
-      GUID_MAPPING      Path to a text file with participant_id to GUID mapping.
-                        You will need to use the GUID Tool
-                        (https://ndar.nih.gov/contribute.html) to generate GUIDs
-                        for your participants.
-      OUTPUT_DIRECTORY  Directory where NDA files will be stored.
+      BIDS_DIRECTORY        Location of the root of your BIDS compatible directory
+      GUID_MAPPING          Path to a text file with participant_id to GUID mapping. You will need to use the GUID Tool (https://ndar.nih.gov/contribute.html) to generate GUIDs for
+                            your participants.
+      OUTPUT_DIRECTORY      Directory where NDA files will be stored
 
-    optional arguments:
-      -h, --help        Show this help message and exit.
-      -e EXPID_MAPPING  Path to a text file with experiment name to NDA experiment ID mapping.
+    options:
+      -h, --help            show this help message and exit
+      -e EXPID_MAPPING, --expid_mapping EXPID_MAPPING
+                            Path to a text file with experiment name to NDA experiment ID mapping.
+      --lookup_csv LOOKUP_CSV
+                            Path to a csv with data we need for the image03.csv, i.e. ndar_subject01.csv
+      --lookup_fields LOOKUP_FIELDS [LOOKUP_FIELDS ...]
+                            List of column names to grab from the lookup csv. i.e. --lookup_fields interview_age sex
 
 
 ## GUID_MAPPING file format
@@ -41,6 +43,22 @@ This is a text file with one line per task present in the dataset in the format:
 The BIDS task name should match the value associated with the "task-" key in the .nii filename.
 
 The NDA experiment ID number(s) are received from NDA after setting the study up through the NDA website [here](https://ndar.nih.gov/user/dashboard/collections.html).
+
+## LOOKUP_CSV
+This can be any csv file, including something like the ndar_subject01.csv, with data
+you want to use to populate the image03.csv file. 
+
+This is useful in cases where the BIDS-derived data is missing or incorrect, such as 
+the calculation of interview_age in months, which is only approximated based on age in years
+from the BIDS data.
+
+## LOOKUP_FIELDS
+If you pass a lookup csv, you need to specify which columns you want to use to populate 
+the image03.csv. The column names must match, so if you're trying to populate the interview_age
+column in the image03.csv, your lookup csv must have a column with the same name. 
+
+You can pass more than one value, separated by spaces, like:
+--lookup_fields interview_age gender
 
 ## Example outputs
 See [/examples](/examples)

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     # Versions should comply with PEP440.  For a discussion on single-sourcing
     # the version across setup.py and the project code, see
     # http://packaging.python.org/en/latest/tutorial.html#version
-    version='0.2.0',
+    version='0.2.1',
 
     description="Command line tool generating NDA compatible description from a Brain Imaging Data Structure "
                 "compatible dataset.",


### PR DESCRIPTION
In the case that values extracted from the BIDS data are missing or incorrect, you can pass a --lookup_csv file and a list of --lookup_fields. For every field listed, the value for that participant is grabbed from the lookup csv and included in the image03.csv instead of the value deduced from the BIDS data.